### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkCudaImage.hxx
+++ b/include/itkCudaImage.hxx
@@ -18,7 +18,6 @@
 #ifndef itkCudaImage_hxx
 #define itkCudaImage_hxx
 
-#include "itkCudaImage.h"
 
 namespace itk
 {

--- a/include/itkCudaImageDataManager.hxx
+++ b/include/itkCudaImageDataManager.hxx
@@ -18,7 +18,6 @@
 #ifndef itkCudaImageDataManager_hxx
 #define itkCudaImageDataManager_hxx
 
-#include "itkCudaImageDataManager.h"
 #include "itkCudaUtil.h"
 //#define VERBOSE
 

--- a/include/itkCudaImageToImageFilter.hxx
+++ b/include/itkCudaImageToImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkCudaImageToImageFilter_hxx
 #define itkCudaImageToImageFilter_hxx
 
-#include "itkCudaImageToImageFilter.h"
 
 namespace itk
 {

--- a/include/itkCudaInPlaceImageFilter.hxx
+++ b/include/itkCudaInPlaceImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkCudaInPlaceImageFilter_hxx
 #define itkCudaInPlaceImageFilter_hxx
 
-#include "itkCudaInPlaceImageFilter.h"
 
 namespace itk
 {

--- a/include/itkCudaSquareImageFilter.hxx
+++ b/include/itkCudaSquareImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkCudaSquareImageFilter_hxx
 
 #include "itkCudaSquareImage.hcu"
-#include "itkCudaSquareImageFilter.h"
 
 namespace itk
 {


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

