### PR TITLE
COMP: Add CUDA include dirs to CudaCommon_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT ITK_SOURCE_DIR)
 endif()
 
 set(CudaCommon_LIBRARIES CudaCommon)
-set(CudaCommon_INCLUDE_DIRS ${CudaCommon_SOURCE_DIR}/include)
+set(CudaCommon_INCLUDE_DIRS ${CudaCommon_SOURCE_DIR}/include ${CUDAToolkit_INCLUDE_DIRS})
 
 # --------------------------------------------------------
 # Find ITK (required)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,5 +11,5 @@ set(CudaCommon_Kernels
 
 itk_module_add_library(CudaCommon ${CudaCommon_SRCS} ${CudaCommon_Kernels})
 target_link_libraries(CudaCommon LINK_PUBLIC CUDA::cudart CUDA::cuda_driver)
-target_include_directories(CudaCommon PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+target_include_directories(CudaCommon PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
 set_property(TARGET CudaCommon PROPERTY CUDA_STANDARD ${CMAKE_CXX_STANDARD})


### PR DESCRIPTION
Fixes "error: cuda.h not found" when wrapping for python.

Prefer CUDAToolkit_INCLUDE_DIRS over CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES
when using find_package(CUDAToolkit).