### PR TITLE
ENH: Publicly links CUDA libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,6 @@ set(CudaCommon_Kernels
   )
 
 itk_module_add_library(CudaCommon ${CudaCommon_SRCS} ${CudaCommon_Kernels})
-target_link_libraries(CudaCommon LINK_PUBLIC CUDA::cudart CUDA::cuda_driver)
+target_link_libraries(CudaCommon PUBLIC CUDA::cudart CUDA::cuda_driver)
 target_include_directories(CudaCommon PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
 set_property(TARGET CudaCommon PROPERTY CUDA_STANDARD ${CMAKE_CXX_STANDARD})


### PR DESCRIPTION
This change is part of CudaCommon migration out of RTK (https://github.com/SimonRit/RTK/pull/427), the linker could note find some CUDA modules and I replaced deprecated PUBLIC_LINK with PUBLIC. 
These changes enable us to not link CUDA to RTK and simply inherit it from CudaCommon.