### PR TITLE
ENH: Add CI for python packages

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -100,3 +100,30 @@ jobs:
     - name: Build and test
       run: |
         ctest --output-on-failure -j 2 -V -S dashboard.cmake
+
+  build-linux-python-packages:
+    runs-on: self-hosted-linux
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version: [37, 38, 39, 310]
+        include:
+          - itk-python-git-tag: "v5.3rc04"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: 'Fetch build script'
+      run: |
+        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
+        chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
+    - name: 'Build 🐍 Python 📦 package'
+      run: |
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
+        export LD_LIBRARY_PATH="/home/srit/Downloads/cuda116:/home/srit/Downloads/cuda116/targets/x86_64-linux/lib:/home/srit/Downloads/cuda116/lib64/stubs"
+        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh -c "-DCUDAToolkit_ROOT=/usr/lib64/cuda116 -DCMAKE_CUDA_COMPILER=/usr/lib64/cuda116/bin/nvcc" -x "libcuda.so;libcuda.so.1;libcudart.so;libcudart.so.11.0;libcublas.so;libcublas.so.11;libcublasLt.so;libcublasLt.so.11;libcufft.so;libcufft.so.10" cp${{ matrix.python-version }}
+    - name: Publish Python package as GitHub Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: LinuxWheel${{ matrix.python-version }}-cuda116
+        path: dist


### PR DESCRIPTION
This MR adds python package build to the CI. Those packages will be needed when using RTK in python since itkCudaCommon is now standalone.